### PR TITLE
Add exchange rate service with fallback sources and UI display

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# Ignore SQLite database files
+*.db
+__pycache__/
+node_modules/

--- a/backend/api.py
+++ b/backend/api.py
@@ -1,0 +1,44 @@
+from flask import Flask, jsonify
+import sqlite3
+
+from .currency_service import (
+    DB_PATH,
+    get_last_update,
+    init_db,
+    update_exchange_rates,
+)
+
+app = Flask(__name__)
+
+
+def _current_rates():
+    conn = sqlite3.connect(DB_PATH)
+    cur = conn.cursor()
+    cur.execute(
+        'SELECT target, rate FROM exchange_rates '
+        'WHERE fetched_at = (SELECT MAX(fetched_at) FROM exchange_rates)'
+    )
+    data = cur.fetchall()
+    conn.close()
+    return dict(data)
+
+
+@app.route('/api/exchange_rates', methods=['GET'])
+def exchange_rates():
+    init_db()
+    last = get_last_update()
+    rates = _current_rates() if last else {}
+    return jsonify({
+        'rates': rates,
+        'last_update': last.isoformat() if last else None,
+    })
+
+
+@app.route('/api/exchange_rates/update', methods=['POST'])
+def manual_update():
+    ts = update_exchange_rates()
+    return jsonify({'updated_at': ts.isoformat()})
+
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/backend/currency_service.py
+++ b/backend/currency_service.py
@@ -1,0 +1,127 @@
+import argparse
+import datetime as dt
+import sqlite3
+import time
+from typing import Dict, Tuple
+
+import requests
+import schedule
+
+DB_PATH = 'exchange_rates.db'
+
+
+def init_db() -> None:
+    """Create the exchange_rates table if it does not already exist."""
+    conn = sqlite3.connect(DB_PATH)
+    cur = conn.cursor()
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS exchange_rates (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            base TEXT NOT NULL,
+            target TEXT NOT NULL,
+            rate REAL NOT NULL,
+            source TEXT NOT NULL,
+            fetched_at TIMESTAMP NOT NULL
+        )
+        """
+    )
+    conn.commit()
+    conn.close()
+
+
+def _fetch_from_cbr() -> Tuple[Dict[str, float], str]:
+    """Fetch rates from the Central Bank of Russia."""
+    url = 'https://www.cbr-xml-daily.ru/daily_json.js'
+    r = requests.get(url, timeout=10)
+    r.raise_for_status()
+    data = r.json()['Valute']
+    rates = {code: info['Value'] for code, info in data.items()}
+    return rates, 'cbr'
+
+
+def _fetch_from_fallback() -> Tuple[Dict[str, float], str]:
+    """Fallback source for exchange rates."""
+    url = 'https://api.exchangerate.host/latest?base=RUB'
+    r = requests.get(url, timeout=10)
+    r.raise_for_status()
+    data = r.json()['rates']
+    return data, 'exchangerate.host'
+
+
+def get_exchange_rates() -> Tuple[Dict[str, float], str]:
+    """Attempt to fetch rates from CBR, falling back to a secondary source."""
+    try:
+        return _fetch_from_cbr()
+    except Exception:
+        try:
+            return _fetch_from_fallback()
+        except Exception as exc:  # pragma: no cover - simple error propagation
+            raise RuntimeError('Failed to fetch exchange rates') from exc
+
+
+def save_rates(rates: Dict[str, float], source: str) -> dt.datetime:
+    """Persist rates to the database and return the timestamp used."""
+    conn = sqlite3.connect(DB_PATH)
+    cur = conn.cursor()
+    now = dt.datetime.utcnow()
+    for target, rate in rates.items():
+        cur.execute(
+            'INSERT INTO exchange_rates (base, target, rate, source, fetched_at) '
+            'VALUES (?, ?, ?, ?, ?)',
+            ('RUB', target, rate, source, now),
+        )
+    conn.commit()
+    conn.close()
+    return now
+
+
+def update_exchange_rates() -> dt.datetime:
+    """Fetch latest rates and store them in the database."""
+    rates, source = get_exchange_rates()
+    return save_rates(rates, source)
+
+
+def get_last_update() -> dt.datetime | None:
+    """Return timestamp of the most recent exchange rates update."""
+    conn = sqlite3.connect(DB_PATH)
+    cur = conn.cursor()
+    cur.execute('SELECT MAX(fetched_at) FROM exchange_rates')
+    row = cur.fetchone()
+    conn.close()
+    if row and row[0]:
+        return dt.datetime.fromisoformat(row[0])
+    return None
+
+
+def schedule_updates() -> None:
+    """Run an update job every 24 hours."""
+    schedule.every(24).hours.do(update_exchange_rates)
+    while True:  # pragma: no cover - long running loop
+        schedule.run_pending()
+        time.sleep(60)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description='Exchange rate updater')
+    parser.add_argument(
+        '--update', action='store_true', help='Run a single manual update and exit'
+    )
+    parser.add_argument(
+        '--schedule', action='store_true', help='Run a scheduler that updates every 24h'
+    )
+    args = parser.parse_args()
+
+    init_db()
+    if args.update:
+        ts = update_exchange_rates()
+        print(f'Updated at {ts.isoformat()}')
+    elif args.schedule:
+        schedule_updates()
+    else:
+        rates, source = get_exchange_rates()
+        print(f'Fetched {len(rates)} rates from {source}')
+
+
+if __name__ == '__main__':
+    main()

--- a/frontend/components/CurrencyRatesDisplay.jsx
+++ b/frontend/components/CurrencyRatesDisplay.jsx
@@ -1,0 +1,39 @@
+import React, { useEffect, useState } from 'react';
+
+function CurrencyRatesDisplay() {
+  const [rates, setRates] = useState({});
+  const [lastUpdate, setLastUpdate] = useState(null);
+
+  const fetchRates = async () => {
+    try {
+      const res = await fetch('/api/exchange_rates');
+      if (res.ok) {
+        const data = await res.json();
+        setRates(data.rates);
+        setLastUpdate(data.last_update);
+      }
+    } catch (err) {
+      console.error('Failed to load rates', err);
+    }
+  };
+
+  useEffect(() => {
+    fetchRates();
+  }, []);
+
+  return (
+    <div>
+      <h2>Exchange Rates</h2>
+      {lastUpdate && (
+        <p>Last update: {new Date(lastUpdate).toLocaleString()}</p>
+      )}
+      <ul>
+        {Object.entries(rates).map(([code, rate]) => (
+          <li key={code}>{code}: {rate}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export default CurrencyRatesDisplay;


### PR DESCRIPTION
## Summary
- implement currency service that fetches rates from the CBR with a fallback provider
- persist fetched rates with source and timestamp and expose update endpoints
- add React component displaying rates and last refresh time

## Testing
- `python -m py_compile backend/currency_service.py backend/api.py`
- `python backend/currency_service.py --update`
- `npx eslint@latest frontend/components/CurrencyRatesDisplay.jsx` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68b6b896d02883278d266a157eea9ac6