### PR TITLE
Add SQLAlchemy database models and init script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+test.db
+__pycache__/

--- a/backend/database/__init__.py
+++ b/backend/database/__init__.py
@@ -1,0 +1,47 @@
+"""Initialize the database and populate it with test data."""
+from sqlalchemy import text
+
+# Support running as a script or as part of a package
+if __name__ == "__main__" and __package__ is None:  # pragma: no cover - runtime import fix
+    import os
+    import sys
+    sys.path.append(os.path.dirname(__file__))
+    from database import Base, engine, get_db  # type: ignore
+    from models import Package, User  # type: ignore
+else:
+    from .database import Base, engine, get_db
+    from .models import Package, User
+
+
+def init_db() -> None:
+    """Create tables and insert a small set of test data."""
+    Base.metadata.create_all(bind=engine)
+
+    db_gen = get_db()
+    db = next(db_gen)
+    try:
+        if not db.query(User).first():
+            user = User(name="Alice", email="alice@example.com")
+            package = Package(description="Sample package", owner=user)
+            db.add(user)
+            db.add(package)
+            db.commit()
+            print("Inserted test data")
+    finally:
+        db_gen.close()
+
+
+def test_connection() -> None:
+    """Verify that a simple statement can be executed."""
+    db_gen = get_db()
+    db = next(db_gen)
+    try:
+        db.execute(text("SELECT 1"))
+        print("Connection OK")
+    finally:
+        db_gen.close()
+
+
+if __name__ == "__main__":
+    init_db()
+    test_connection()

--- a/backend/database/database.py
+++ b/backend/database/database.py
@@ -1,0 +1,22 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, declarative_base
+
+DATABASE_URL = "sqlite:///./test.db"
+
+# SQLite specific flag required for working with SQLAlchemy's async features.
+engine = create_engine(
+    DATABASE_URL, connect_args={"check_same_thread": False}
+)
+
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+Base = declarative_base()
+
+
+def get_db():
+    """Yield a database session and ensure it is closed afterwards."""
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/backend/database/models.py
+++ b/backend/database/models.py
@@ -1,0 +1,27 @@
+from sqlalchemy import Column, ForeignKey, Integer, String
+from sqlalchemy.orm import relationship
+
+try:  # Allow importing when executed as a script
+    from .database import Base
+except ImportError:  # pragma: no cover - for script execution
+    from database import Base  # type: ignore
+
+
+class User(Base):
+    __tablename__ = "users"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, index=True, nullable=False)
+    email = Column(String, unique=True, index=True, nullable=False)
+
+    packages = relationship("Package", back_populates="owner")
+
+
+class Package(Base):
+    __tablename__ = "packages"
+
+    id = Column(Integer, primary_key=True, index=True)
+    description = Column(String, index=True, nullable=False)
+    owner_id = Column(Integer, ForeignKey("users.id"))
+
+    owner = relationship("User", back_populates="packages")


### PR DESCRIPTION
## Summary
- define SQLAlchemy engine, session factory, and get_db helper
- add User and Package models with relationships
- add initialization script to create tables and seed test data

## Testing
- `python backend/database/__init__.py`
- `python - <<'PY'
from backend.database.database import get_db
from sqlalchemy import text

db_gen = get_db()
db = next(db_gen)
try:
    result = db.execute(text('SELECT 1')).scalar_one()
    print('Result:', result)
finally:
    db_gen.close()
PY`


------
https://chatgpt.com/codex/tasks/task_e_68b6b89887288327b70eb1304f73108a